### PR TITLE
Add a basic Leaflet map w/Mapbox tilelayer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5338,6 +5338,11 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leaflet": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.3.1.tgz",
+      "integrity": "sha512-adQOIzh+bfdridLM1xIgJ9VnJbAUY3wqs/ueF+ITla+PLQ1z47USdBKUf+iD9FuUA8RtlT6j6hZBfZoA6mW+XQ=="
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "d3": "^4.13.0",
+    "leaflet": "^1.3.1",
     "turf": "^3.0.14"
   },
   "devDependencies": {

--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,10 @@
   <body>
 
     <div class="content-wrapper">
-      <h1>AMNH Collections Mapper</h1>
+
+      <header>
+        <h1 class="title">AMNH Collections Mapper</h1>
+      </header>
 
       <!-- mount the map here (whether d3, react, leaflet, mapbox.gl, etc.) -->
       <div id="map"></div>

--- a/source/js/map.js
+++ b/source/js/map.js
@@ -1,1 +1,31 @@
-console.log('This is where the map code will go')
+import * as L from 'leaflet'
+import 'Leaflet/leaflet.css'
+
+var mapboxAccessToken = 'pk.eyJ1IjoiYmZyaWVkbHkiLCJhIjoiY2pkaTR2dnNhMTVkaDJxcDRvaHI1NThmaiJ9.1wgZ8MHW-Fa064snlrDC1w';
+
+// instantiate a Leaflet map instance
+var map = L.map('map', {
+  minZoom: 1,
+  maxZoom: 13
+}).setView([0,0],2);
+
+/*** EVENT FUNCTIONS FOR INSPECTING IN CONSOLE -- DEV ***/
+  map.on('zoom', () => {
+    console.log('Zoomed')
+    console.log(map.getCenter())
+    console.log(map.getZoom())
+  })
+  map.on('move', () => {
+    console.log('Zoomed')
+    console.log(map.getCenter())
+    console.log(map.getZoom())
+  })
+/*** END OF EVENT FUNCTIONS  ***/
+
+//  add a tilelayer for the basemap using Mapbox tile service
+L.tileLayer(`https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}`, {
+    attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+    maxZoom: 18,
+    id: 'mapbox.streets',
+    accessToken: mapboxAccessToken
+}).addTo(map);

--- a/source/styles/main.scss
+++ b/source/styles/main.scss
@@ -3,6 +3,9 @@
 // import variables
 @import 'colors';
 
+// import map-specific style
+@import 'map';
+
 * {
   box-sizing: border-box;
 }
@@ -12,14 +15,32 @@
   margin: 0 auto; // align center
   height: 100vh;
   display: grid;
+  align-items: center;
   grid-gap: 20px;
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 100px 1fr 100px;
   border: 5px solid $amnh-blue;
 }
 
-#map  {
-  height: 500px;
-  width: 600px;
-  background-color: $amnh-blue;
+header {
+  grid-column: 1/4;
+  grid-row: 1;
+  height: 100%;
+  background-color: grey;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+//just the layout of the map - see ./map.scss for other styling
+#map {
+  height: 100%;
+  width: 100%;
+  grid-column: 1/4;
+  grid-row: 2/4;
+}
+
+h1 {
+  font-family: sans-serif;
+  font-size: 24px;
 }

--- a/source/styles/map.scss
+++ b/source/styles/map.scss
@@ -1,0 +1,3 @@
+//  placeholder for any map-specific styling
+#map  {
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,11 @@ module.exports = {
     open: true,
     hot: true
   },
+  resolve: {
+    alias: {
+      Leaflet: path.resolve(__dirname, 'node_modules/leaflet/dist')
+    }
+  },
   plugins: [
     new webpack.NamedModulesPlugin(),
     new webpack.HotModuleReplacementPlugin()
@@ -22,7 +27,7 @@ module.exports = {
     rules: [
       // styles
       {
-        test: /\.scss$/,
+        test: /\.(scss|css)$/,
         use: [
           'style-loader',
           'css-loader',


### PR DESCRIPTION
This instantiates a basic leaflet map using Mapbox as a tile server for the basemap.  
![screen shot 2018-02-10 at 9 40 05 pm](https://user-images.githubusercontent.com/5316367/36068765-09adc42c-0eab-11e8-88fa-63fc030d5bea.png)

Using Leaflet is the simplest way for now to get a map that pans, zooms, and has a pretty basemap.  There are examples available for how to integrate Leaflet with D3.  We should use D3 for the layer styling (and additional graphs / charts).  

**D3 + Leaflet reference:**

- [Mike Bostock example](https://bost.ocks.org/mike/leaflet/)
- [D3.js Tips and Tricks - D3 & Leaflet](http://www.d3noob.org/2014/03/leaflet-map-with-d3js-elements-that-are.html)
